### PR TITLE
feat: fix all current lint error.

### DIFF
--- a/packages/fe-tw/biome.json
+++ b/packages/fe-tw/biome.json
@@ -12,7 +12,7 @@
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
-    "indentSize": 2
+    "indentWidth": 2
   },
   "organizeImports": {
     "enabled": true

--- a/packages/fe-tw/src/app/building/[id]/admin/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/admin/page.tsx
@@ -18,7 +18,8 @@ export default function AdminPage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/expenses/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/expenses/page.tsx
@@ -18,7 +18,8 @@ export default function ExpensesPage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/page.tsx
@@ -18,7 +18,8 @@ export default function Home({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/payments/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/payments/page.tsx
@@ -18,7 +18,8 @@ export default function PaymentsPage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/proposals/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/proposals/page.tsx
@@ -18,7 +18,8 @@ export default function ProposalsPage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/slices/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/slices/page.tsx
@@ -18,7 +18,8 @@ export default function SlicesPage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/staking/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/staking/page.tsx
@@ -18,7 +18,8 @@ export default function StakingPage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/building/[id]/trade/page.tsx
+++ b/packages/fe-tw/src/app/building/[id]/trade/page.tsx
@@ -26,7 +26,8 @@ export default function TradePage({ params }: Props) {
 
   if (!buildings?.length || !id) {
     return <LoadingView isLoading />;
-  } else if (!building) {
+  }
+  if (!building) {
     return <p>Not found</p>;
   }
 

--- a/packages/fe-tw/src/app/faq/page.tsx
+++ b/packages/fe-tw/src/app/faq/page.tsx
@@ -121,6 +121,7 @@ Join our community or visit our GitHub for hands-on examples and updates.
 
       <div className="space-y-4">
         {faqs.map((faq) => (
+          // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
           <div
             key={faq.question}
             className="
@@ -153,7 +154,10 @@ Join our community or visit our GitHub for hands-on examples and updates.
 
       <div className="text-center mt-6">
         <Link href="/explorer">
-          <button className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition">
+          <button
+            className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition"
+            type="button"
+          >
             Back to Explorer
           </button>
         </Link>

--- a/packages/fe-tw/src/app/landing/page.tsx
+++ b/packages/fe-tw/src/app/landing/page.tsx
@@ -58,7 +58,10 @@ export default function Landing() {
             Building a REIT using web3 technologies
           </p>
           <Link href="/explorer">
-            <button className="btn btn-primary btn-xs sm:btn-sm md:btn-md lg:btn-lg bg-purple-600 text-white rounded-full hover:bg-purple-700">
+            <button
+              className="btn btn-primary btn-xs sm:btn-sm md:btn-md lg:btn-lg bg-purple-600 text-white rounded-full hover:bg-purple-700"
+              type="button"
+            >
               Explore
             </button>
           </Link>
@@ -67,6 +70,7 @@ export default function Landing() {
         {/* Scroll-down hint */}
         <div className="mb-8 text-center slow-bounce">
           <p className="text-gray-700 text-sm mb-4">Scroll to Explore</p>
+          {/* biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-6 w-6 text-gray-700 mx-auto"

--- a/packages/fe-tw/src/components/Admin/AddBuildingTokenLiquidityForm.tsx
+++ b/packages/fe-tw/src/components/Admin/AddBuildingTokenLiquidityForm.tsx
@@ -102,7 +102,7 @@ export function AddBuildingTokenLiquidityForm({
         label: "USDC",
       },
     ],
-    [deployedBuildingTokens?.length],
+    [deployedBuildingTokens],
   );
 
   const buildingSelectOptions = useMemo(() => {
@@ -110,7 +110,7 @@ export function AddBuildingTokenLiquidityForm({
       value: building.address as `0x${string}`,
       label: building.title,
     }));
-  }, [buildings?.length]);
+  }, [buildings]);
 
   return (
     <div className="bg-white rounded-lg p-8 border border-gray-300">
@@ -140,7 +140,10 @@ export function AddBuildingTokenLiquidityForm({
 
             {!buildingAddress && (
               <div>
-                <label className="block text-md font-semibold text-purple-400">
+                <label
+                  className="block text-md font-semibold text-purple-400"
+                  htmlFor=""
+                >
                   Select Building
                 </label>
                 <Select
@@ -167,7 +170,10 @@ export function AddBuildingTokenLiquidityForm({
 
             {/* Token A */}
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor=""
+              >
                 Select Token A
               </label>
               <Select
@@ -194,7 +200,10 @@ export function AddBuildingTokenLiquidityForm({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="tokenAAmount"
+              >
                 Token A Amount
               </label>
               <Field
@@ -206,7 +215,10 @@ export function AddBuildingTokenLiquidityForm({
 
             {/* Token B */}
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor=""
+              >
                 Select Token B
               </label>
               <Select
@@ -233,7 +245,10 @@ export function AddBuildingTokenLiquidityForm({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="tokenBAmount"
+              >
                 Token B Amount
               </label>
               <Field

--- a/packages/fe-tw/src/components/Admin/AddSliceAllocationForm.tsx
+++ b/packages/fe-tw/src/components/Admin/AddSliceAllocationForm.tsx
@@ -59,7 +59,7 @@ export const AddSliceAllocationForm = ({ handleBack }: Props) => {
         value: token.address as string,
         label: token.name,
       })),
-    [autoCompounders?.length],
+    [autoCompounders],
   );
 
   const sliceOptions = useMemo(
@@ -68,7 +68,7 @@ export const AddSliceAllocationForm = ({ handleBack }: Props) => {
         value: slice.address,
         label: slice.name,
       })),
-    [slices?.length],
+    [slices],
   );
 
   const submitAddAllocationForm = useCallback(
@@ -101,7 +101,7 @@ export const AddSliceAllocationForm = ({ handleBack }: Props) => {
         });
       });
     },
-    [sliceAddress],
+    [sliceAddress, writeContract, watch],
   );
 
   return (
@@ -110,7 +110,10 @@ export const AddSliceAllocationForm = ({ handleBack }: Props) => {
         {({ setFieldValue, values }) => (
           <Form className="space-y-4">
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor=""
+              >
                 Select Slice
               </label>
               <Select
@@ -136,7 +139,10 @@ export const AddSliceAllocationForm = ({ handleBack }: Props) => {
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="allocation"
+              >
                 Token Allocation (%)
               </label>
               <Field
@@ -146,7 +152,10 @@ export const AddSliceAllocationForm = ({ handleBack }: Props) => {
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor=""
+              >
                 Select Token Asset (Auto Compounder Token)
               </label>
               <Select

--- a/packages/fe-tw/src/components/Admin/AddSliceForm.tsx
+++ b/packages/fe-tw/src/components/Admin/AddSliceForm.tsx
@@ -31,7 +31,10 @@ export const AddSliceForm = ({
         return (
           <Form className="space-y-4">
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="name"
+              >
                 Slice Name
               </label>
               <Field
@@ -41,7 +44,10 @@ export const AddSliceForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="description"
+              >
                 Slice Description
               </label>
               <Field
@@ -51,7 +57,10 @@ export const AddSliceForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="endDate"
+              >
                 Slice End Date
               </label>
               <Field

--- a/packages/fe-tw/src/components/Admin/DeployBuildingVaultCompounderForm.tsx
+++ b/packages/fe-tw/src/components/Admin/DeployBuildingVaultCompounderForm.tsx
@@ -67,7 +67,7 @@ const DeployVaultForm = ({
         label: "USDC",
       },
     ],
-    [buildingDeployedTokens?.length],
+    [buildingDeployedTokens],
   );
 
   return (
@@ -77,7 +77,10 @@ const DeployVaultForm = ({
         {({ setFieldValue, values }) => (
           <Form className="space-y-4">
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor=""
+              >
                 Staking token
               </label>
               <Select
@@ -104,7 +107,10 @@ const DeployVaultForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="shareTokenName"
+              >
                 Share token name
               </label>
               <Field
@@ -114,7 +120,10 @@ const DeployVaultForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="shareTokenSymbol"
+              >
                 Share token symbol
               </label>
               <Field
@@ -124,7 +133,10 @@ const DeployVaultForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="feeReceiver"
+              >
                 Fee receiver address
               </label>
               <Field
@@ -134,7 +146,10 @@ const DeployVaultForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="feeToken"
+              >
                 Fee token
               </label>
               <Field
@@ -144,7 +159,10 @@ const DeployVaultForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="feePercentage"
+              >
                 Fee percentage
               </label>
               <Field
@@ -203,7 +221,10 @@ const DeployAutoCompounderForm = ({
         {({ setFieldValue, values }) => (
           <Form className="space-y-4">
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="tokenName"
+              >
                 Token name
               </label>
               <Field
@@ -213,7 +234,10 @@ const DeployAutoCompounderForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor="tokenSymbol"
+              >
                 Token symbol
               </label>
               <Field
@@ -223,7 +247,10 @@ const DeployAutoCompounderForm = ({
               />
             </div>
             <div>
-              <label className="block text-md font-semibold text-purple-400">
+              <label
+                className="block text-md font-semibold text-purple-400"
+                htmlFor=""
+              >
                 Asset token
               </label>
               <Select

--- a/packages/fe-tw/src/components/Admin/TokenManagementView.tsx
+++ b/packages/fe-tw/src/components/Admin/TokenManagementView.tsx
@@ -19,17 +19,19 @@ export function TokenManagementView() {
           }}
         />
       );
-    } else if (currentSetupStep === 2) {
+    }
+    if (currentSetupStep === 2) {
       return (
         <AddBuildingTokenLiquidityForm
           buildingAddress={selectedBuildingAddress}
           onGetDeployBuildingTokenView={() => {
             setCurrentSetupStep(2);
           }}
+          onGetDeployATokenView={() => {}}
         />
       );
     }
-  }, [currentSetupStep]);
+  }, [currentSetupStep, selectedBuildingAddress]);
 
   return (
     <div className="p-6 max-w-7xl mx-auto space-y-6">

--- a/packages/fe-tw/src/components/Audit/AuditModal.tsx
+++ b/packages/fe-tw/src/components/Audit/AuditModal.tsx
@@ -73,6 +73,7 @@ export function AuditModal({
     <div className="modal modal-open">
       <div className="modal-box max-w-xl relative">
         <button
+          type="button"
           className="btn btn-sm btn-circle absolute right-2 top-2"
           onClick={onClose}
         >
@@ -84,7 +85,7 @@ export function AuditModal({
         <form onSubmit={handleSubmit} className="space-y-4 mt-4">
           {/* Insurance Provider */}
           <div>
-            <label className="block mb-1 font-semibold">
+            <label className="block mb-1 font-semibold" htmlFor="">
               Insurance Provider
             </label>
             <input
@@ -98,7 +99,9 @@ export function AuditModal({
 
           {/* Coverage Amount */}
           <div>
-            <label className="block mb-1 font-semibold">Coverage Amount</label>
+            <label className="block mb-1 font-semibold" htmlFor="">
+              Coverage Amount
+            </label>
             <input
               className="input input-bordered w-full"
               type="text"
@@ -110,7 +113,9 @@ export function AuditModal({
 
           {/* Coverage Start */}
           <div>
-            <label className="block mb-1 font-semibold">Coverage Start</label>
+            <label className="block mb-1 font-semibold" htmlFor="">
+              Coverage Start
+            </label>
             <input
               className="input input-bordered w-full"
               type="date"
@@ -122,7 +127,9 @@ export function AuditModal({
 
           {/* Coverage End */}
           <div>
-            <label className="block mb-1 font-semibold">Coverage End</label>
+            <label className="block mb-1 font-semibold" htmlFor="">
+              Coverage End
+            </label>
             <input
               className="input input-bordered w-full"
               type="date"
@@ -134,7 +141,9 @@ export function AuditModal({
 
           {/* Notes */}
           <div>
-            <label className="block mb-1 font-semibold">Notes</label>
+            <label className="block mb-1 font-semibold" htmlFor="">
+              Notes
+            </label>
             <textarea
               className="textarea textarea-bordered w-full"
               rows={3}

--- a/packages/fe-tw/src/components/Buttons/BackButton.tsx
+++ b/packages/fe-tw/src/components/Buttons/BackButton.tsx
@@ -8,9 +8,11 @@ type Props = {
 export const BackButton = ({ onHandlePress, styleClasses }: Props) => {
   return (
     <button
+      type="button"
       className={`bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center${styleClasses ? styleClasses.map((styleClass) => ` ${styleClass}`) : ""}`}
       onClick={onHandlePress}
     >
+      {/* biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"

--- a/packages/fe-tw/src/components/Buttons/CopeAdminUpdateButton.tsx
+++ b/packages/fe-tw/src/components/Buttons/CopeAdminUpdateButton.tsx
@@ -11,6 +11,7 @@ export function CopeAdminUpdateButton({
 }: CopeAdminUpdateButtonProps) {
   return (
     <button
+      type="button"
       onClick={onClick}
       disabled={isLoading}
       className="w-full py-2 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-full"

--- a/packages/fe-tw/src/components/Buttons/PlayButton.tsx
+++ b/packages/fe-tw/src/components/Buttons/PlayButton.tsx
@@ -12,6 +12,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({ href }) => {
       href={href}
       className="absolute bottom-4 right-4 bg-purple-100 rounded-full w-12 h-12 flex items-center justify-center hover:bg-purple-200 transition"
     >
+      {/* biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"

--- a/packages/fe-tw/src/components/Buttons/RebalanceButton.tsx
+++ b/packages/fe-tw/src/components/Buttons/RebalanceButton.tsx
@@ -26,6 +26,7 @@ export default function RebalanceButton({ sliceName }: RebalanceButtonProps) {
 
   return (
     <button
+      type="button"
       className={`bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded ${
         isRebalancing ? "opacity-50 cursor-not-allowed" : ""
       }`}

--- a/packages/fe-tw/src/components/Expenses/ExpenseForm.tsx
+++ b/packages/fe-tw/src/components/Expenses/ExpenseForm.tsx
@@ -35,7 +35,7 @@ export function ExpenseForm({ buildingId, onCompleted }: ExpenseFormProps) {
     e.preventDefault();
 
     const amt = Number.parseFloat(amount);
-    if (isNaN(amt) || amt <= 0) {
+    if (Number.isNaN(amt) || amt <= 0) {
       toast.error("Invalid expense amount");
       return;
     }

--- a/packages/fe-tw/src/components/Expenses/ExpensesView.tsx
+++ b/packages/fe-tw/src/components/Expenses/ExpensesView.tsx
@@ -105,7 +105,10 @@ export function ExpensesView({ buildingId }: ExpensesViewProps) {
                       </span>
                     </td>
                     <td className="p-3 text-blue-500 rounded-r-lg">
-                      <button className="flex items-center gap-2 hover:underline">
+                      <button
+                        className="flex items-center gap-2 hover:underline"
+                        type="button"
+                      >
                         Details
                       </button>
                     </td>
@@ -119,6 +122,7 @@ export function ExpensesView({ buildingId }: ExpensesViewProps) {
 
       <div className="flex justify-end">
         <button
+          type="button"
           className="btn btn-primary text-white text-base font-normal"
           onClick={() => setShowModal(true)}
         >
@@ -159,6 +163,7 @@ function ExpenseModal({
     <div className="modal modal-open">
       <div className="modal-box relative max-w-md">
         <button
+          type="button"
           className="btn btn-sm btn-circle absolute right-2 top-2"
           onClick={onClose}
         >

--- a/packages/fe-tw/src/components/Explorer/BuildingsCarousel.tsx
+++ b/packages/fe-tw/src/components/Explorer/BuildingsCarousel.tsx
@@ -37,6 +37,7 @@ export function BuildingsCarousel({ title, buildings }: Props) {
       <div className="relative">
         {/* Previous Button */}
         <button
+          type="button"
           onClick={goToPrevious}
           className="absolute left-0 top-1/2 -translate-y-1/2 z-10 btn btn-circle bg-gray-200 bg-opacity-70 text-gray-500 hover:bg-gray-300 hover:text-gray-600 transition-all"
         >
@@ -72,6 +73,7 @@ export function BuildingsCarousel({ title, buildings }: Props) {
 
         {/* Next Button */}
         <button
+          type="button"
           onClick={goToNext}
           className="absolute right-0 top-1/2 -translate-y-1/2 z-10 btn btn-circle bg-gray-200 bg-opacity-70 text-gray-500 hover:bg-gray-300 hover:text-gray-600 transition-all"
         >

--- a/packages/fe-tw/src/components/Explorer/ExplorerView.tsx
+++ b/packages/fe-tw/src/components/Explorer/ExplorerView.tsx
@@ -19,7 +19,7 @@ export function ExplorerView() {
 
   return (
     <div className="max-w-screen-xl mx-auto px-8 md:px-12 lg:px-20">
-      <Link href={`/slices`}>
+      <Link href={"/slices"}>
         <h2 className="text-lg font-semibold mt-8">Featured Slices →</h2>
       </Link>
       <br />

--- a/packages/fe-tw/src/components/Explorer/SlicesCarousel.tsx
+++ b/packages/fe-tw/src/components/Explorer/SlicesCarousel.tsx
@@ -34,6 +34,7 @@ export function SlicesCarousel({
   return (
     <div className="flex overflow-x-auto space-x-4 md:space-x-6 p-2">
       {slices.map((slice) => (
+        // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
         <div
           key={slice.id}
           className={`group flex-shrink-0 w-32 md:w-48 cursor-pointer transition-all duration-300 ${

--- a/packages/fe-tw/src/components/FetchViews/BuildingDetailsView.tsx
+++ b/packages/fe-tw/src/components/FetchViews/BuildingDetailsView.tsx
@@ -13,7 +13,7 @@ export const BuildingDetailsView = ({ address, setBuildingTokens }: Props) => {
     if (deployedBuildingTokens?.length) {
       setBuildingTokens((prev: any) => [...prev, ...deployedBuildingTokens]);
     }
-  }, [deployedBuildingTokens?.length]);
+  }, [deployedBuildingTokens, setBuildingTokens]);
 
   return <></>;
 };

--- a/packages/fe-tw/src/components/Footers/Footer.tsx
+++ b/packages/fe-tw/src/components/Footers/Footer.tsx
@@ -14,6 +14,7 @@ export const Footer = () => {
           className="bottom-auto top-0 left-0 right-0 w-full absolute pointer-events-none overflow-hidden -mt-20 h-20"
           style={{ transform: "translateZ(0)" }}
         >
+          {/* biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
           <svg
             className="absolute bottom-0 overflow-hidden"
             xmlns="http://www.w3.org/2000/svg"
@@ -39,13 +40,22 @@ export const Footer = () => {
                 Stay in the loop
               </h5>
               <div className="flex justify-center lg:justify-start space-x-4">
-                <button className="btn btn-circle bg-white text-gray-600 shadow-md hover:bg-gray-200">
+                <button
+                  type="button"
+                  className="btn btn-circle bg-white text-gray-600 shadow-md hover:bg-gray-200"
+                >
                   <i className="fab fa-twitter" />
                 </button>
-                <button className="btn btn-circle bg-white text-gray-600 shadow-md hover:bg-gray-200">
+                <button
+                  type="button"
+                  className="btn btn-circle bg-white text-gray-600 shadow-md hover:bg-gray-200"
+                >
                   <i className="fab fa-discord" />
                 </button>
-                <button className="btn btn-circle bg-white text-gray-600 shadow-md hover:bg-gray-200">
+                <button
+                  type="button"
+                  className="btn btn-circle bg-white text-gray-600 shadow-md hover:bg-gray-200"
+                >
                   <i className="fab fa-github" />
                 </button>
               </div>
@@ -61,7 +71,10 @@ export const Footer = () => {
                     placeholder="Your email address"
                     className="input input-bordered input-sm w-56 mb-2"
                   />
-                  <button className="btn btn-sm bg-gray-200 text-gray-700 hover:bg-gray-300 w-56">
+                  <button
+                    className="btn btn-sm bg-gray-200 text-gray-700 hover:bg-gray-300 w-56"
+                    type="button"
+                  >
                     Subscribe
                   </button>
                 </form>

--- a/packages/fe-tw/src/components/Navbar/Navbar.tsx
+++ b/packages/fe-tw/src/components/Navbar/Navbar.tsx
@@ -17,7 +17,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       const detailsEl = explorerDetailsRef.current;
-      if (detailsEl && detailsEl.hasAttribute("open")) {
+      if (detailsEl?.hasAttribute("open")) {
         if (!detailsEl.contains(event.target as Node)) {
           detailsEl.removeAttribute("open");
         }
@@ -45,10 +45,12 @@ export function Navbar({ children }: { children: React.ReactNode }) {
           {/* Hamburger Menu (mobile) */}
           <div className="lg:hidden">
             <button
+              type="button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="btn btn-square btn-ghost"
               aria-label="Toggle menu"
             >
+              {/* biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -75,6 +77,7 @@ export function Navbar({ children }: { children: React.ReactNode }) {
                 "
               >
                 Explorer
+                {/* biome-ignore lint/a11y/noSvgWithoutTitle: <explanation> */}
                 <svg
                   className="ml-1 w-4 h-4 text-gray-600 group-hover:text-gray-800"
                   fill="currentColor"

--- a/packages/fe-tw/src/components/Page/BuildingManagementViewBreadcrumbs.tsx
+++ b/packages/fe-tw/src/components/Page/BuildingManagementViewBreadcrumbs.tsx
@@ -19,12 +19,14 @@ export const BuildingManagementViewBreadcrumbs = ({
   return (
     <div className="breadcrumbs text-sm text-gray-700 mb-4">
       <ul>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
         <li onClick={onGetDeployBuilding}>
           <p className={activeStepOn === 1 ? activeTextStyle : textStyle}>
             <ArrowBack fontSize="small" />
             <span className="ml-2">Deploy Building</span>
           </p>
         </li>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
         <li onClick={onGetDeployAToken}>
           <p className={activeStepOn === 6 ? activeTextStyle : textStyle}>
             <span>Deploy A Token</span>

--- a/packages/fe-tw/src/components/Page/PageRedirect.tsx
+++ b/packages/fe-tw/src/components/Page/PageRedirect.tsx
@@ -13,7 +13,7 @@ export const PageRedirect = ({
     if (notFound) {
       replace("/not-found");
     }
-  }, [notFound]);
+  }, [notFound, replace]);
 
   return !notFound && children;
 };

--- a/packages/fe-tw/src/components/Payments/PaymentForm.tsx
+++ b/packages/fe-tw/src/components/Payments/PaymentForm.tsx
@@ -19,7 +19,7 @@ export function PaymentForm({ buildingId, onCompleted }: PaymentFormProps) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const amt = Number.parseFloat(amount);
-    if (isNaN(amt) || amt <= 0) {
+    if (Number.isNaN(amt) || amt <= 0) {
       toast.error("Invalid amount");
       return;
     }

--- a/packages/fe-tw/src/components/Payments/PaymentsView.tsx
+++ b/packages/fe-tw/src/components/Payments/PaymentsView.tsx
@@ -95,7 +95,10 @@ export function PaymentsView({ buildingId }: PaymentsViewProps) {
                       </span>
                     </td>
                     <td className="p-3 text-blue-500 rounded-r-lg">
-                      <button className="flex items-center gap-2 hover:underline">
+                      <button
+                        type="button"
+                        className="flex items-center gap-2 hover:underline"
+                      >
                         Details
                       </button>
                     </td>
@@ -109,6 +112,7 @@ export function PaymentsView({ buildingId }: PaymentsViewProps) {
 
       <div className="flex justify-end">
         <button
+          type="button"
           onClick={() => setShowPaymentModal(true)}
           className="btn btn-primary text-white text-base font-normal"
         >
@@ -144,6 +148,7 @@ function PaymentModal({
     <div className="modal modal-open">
       <div className="modal-box relative max-w-md">
         <button
+          type="button"
           className="btn btn-sm btn-circle absolute right-2 top-2"
           onClick={onClose}
         >

--- a/packages/fe-tw/src/components/Proposals/CreateProposalForm.tsx
+++ b/packages/fe-tw/src/components/Proposals/CreateProposalForm.tsx
@@ -142,6 +142,7 @@ export function CreateProposalForm({ onSubmit }: CreateProposalFormProps) {
         )}
       </div>
       <button
+        type="button"
         className="btn btn-primary w-full"
         onClick={handleSubmit}
         disabled={!formData.title || !formData.description}

--- a/packages/fe-tw/src/components/Proposals/ProposalItem.tsx
+++ b/packages/fe-tw/src/components/Proposals/ProposalItem.tsx
@@ -56,6 +56,7 @@ export function ProposalItem({
         {!concluded && !hasVoted && (
           <div className="flex gap-2">
             <button
+              type="button"
               className="w-10 h-10 border-2 border-purple-500 text-purple-500 flex items-center justify-center rounded-full hover:bg-purple-100 transition"
               onClick={() => handleVote("yes")}
               aria-label="Vote Yes"
@@ -64,6 +65,7 @@ export function ProposalItem({
             </button>
 
             <button
+              type="button"
               className="w-10 h-10 bg-gray-200 text-white flex items-center justify-center rounded-full hover:bg-gray-300 transition"
               onClick={() => handleVote("no")}
               aria-label="Vote No"
@@ -105,6 +107,7 @@ export function ProposalItem({
       </div>
 
       <button
+        type="button"
         className="btn btn-link btn-sm text-purple-600 mt-2"
         onClick={onToggleExpand}
       >

--- a/packages/fe-tw/src/components/Proposals/ProposalsView.tsx
+++ b/packages/fe-tw/src/components/Proposals/ProposalsView.tsx
@@ -106,6 +106,7 @@ export function ProposalsView() {
       {/* Tabs titles*/}
       <div className="flex space-x-8 mb-4">
         <button
+          type="button"
           className={`text-2l ${
             selectedTab === "active" ? "font-bold text-black" : "text-gray-400"
           }`}
@@ -114,6 +115,7 @@ export function ProposalsView() {
           Active Proposals
         </button>
         <button
+          type="button"
           className={`text-2l ${
             selectedTab === "past" ? "font-bold text-black" : "text-gray-400"
           }`}
@@ -144,7 +146,11 @@ export function ProposalsView() {
           </select>
         </div>
 
-        <button className="btn btn-primary" onClick={() => setShowModal(true)}>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => setShowModal(true)}
+        >
           Create New Proposal
         </button>
       </div>
@@ -167,6 +173,7 @@ export function ProposalsView() {
         <div className="modal modal-open">
           <div className="modal-box relative max-w-lg">
             <button
+              type="button"
               className="btn btn-sm btn-circle absolute right-2 top-2"
               onClick={() => setShowModal(false)}
             >

--- a/packages/fe-tw/src/components/Slices/AllocationBuildingToken.tsx
+++ b/packages/fe-tw/src/components/Slices/AllocationBuildingToken.tsx
@@ -15,7 +15,7 @@ export const AllocationBuildingToken = ({
   showOnDetails = false,
 }: Props) => {
   const buildingToken = sliceBuildings.find(
-    (_) => _?.tokenAddress == allocation.buildingToken,
+    (_) => _?.tokenAddress === allocation.buildingToken,
   );
   const { buildings } = useBuildings();
 

--- a/packages/fe-tw/src/components/Slices/Allocations.tsx
+++ b/packages/fe-tw/src/components/Slices/Allocations.tsx
@@ -27,6 +27,7 @@ export default function Allocations({
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-2xl font-bold">Allocations</h2>
           <button
+            type="button"
             onClick={onClose}
             className="text-gray-500 hover:text-gray-700"
           >
@@ -69,6 +70,7 @@ export default function Allocations({
 
         <div className="flex justify-end space-x-4">
           <button
+            type="button"
             onClick={onClose}
             className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded"
           >

--- a/packages/fe-tw/src/components/Slices/SliceCardGrid.tsx
+++ b/packages/fe-tw/src/components/Slices/SliceCardGrid.tsx
@@ -49,7 +49,7 @@ export default function SliceCardGrid({ sliceIds }: SliceCardGridProps) {
                     <span className="font-medium">Allocations:</span>{" "}
                     {slice.allocation}%
                   </p>
-                  <div className="my-2"></div> {/* Line break */}
+                  <div className="my-2" /> {/* Line break */}
                 </>
               )}
 

--- a/packages/fe-tw/src/components/Slices/SliceDetailPage.tsx
+++ b/packages/fe-tw/src/components/Slices/SliceDetailPage.tsx
@@ -114,6 +114,7 @@ export function SliceDetailPage({
             Slice Token Allocations
           </h2>
           <button
+            type="button"
             className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition"
             onClick={openModal}
           >

--- a/packages/fe-tw/src/components/Staking/ManageStake.tsx
+++ b/packages/fe-tw/src/components/Staking/ManageStake.tsx
@@ -95,10 +95,14 @@ export default function ManageStake({
       </div>
 
       <div className="flex gap-4 justify-center">
-        <button className="btn btn-primary" onClick={handleStake}>
+        <button type="button" className="btn btn-primary" onClick={handleStake}>
           Stake
         </button>
-        <button className="btn btn-secondary" onClick={handleUnstake}>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={handleUnstake}
+        >
           Unstake
         </button>
       </div>

--- a/packages/fe-tw/src/components/Staking/StakingShareChart.tsx
+++ b/packages/fe-tw/src/components/Staking/StakingShareChart.tsx
@@ -44,7 +44,7 @@ const StakingShareChart = ({
             >
               {chartData.map((entry, index) => (
                 <Cell
-                  key={`cell-${index}`}
+                  key={`cell-${entry.name}`}
                   fill={COLORS[index % COLORS.length]}
                 />
               ))}

--- a/packages/fe-tw/src/components/Staking/VotingPower.tsx
+++ b/packages/fe-tw/src/components/Staking/VotingPower.tsx
@@ -48,7 +48,7 @@ export default function VotingPower({
       </div>
 
       <div className="mt-4">
-        <button className="btn btn-primary w-full">
+        <button type="button" className="btn btn-primary w-full">
           Delegate Voting Power
         </button>
       </div>

--- a/packages/fe-tw/src/components/Trade/ProfitGraph.tsx
+++ b/packages/fe-tw/src/components/Trade/ProfitGraph.tsx
@@ -43,6 +43,7 @@ export default function ProfitGraph({
       <div className="absolute top-6 right-6 flex gap-2">
         {["D", "W", "M", "Y"].map((label) => (
           <button
+            type="button"
             key={label}
             onClick={() => setView(label as "D" | "W" | "M" | "Y")}
             className={`px-4 py-1 rounded-full font-semibold ${

--- a/packages/fe-tw/src/components/Trade/TradeForm.tsx
+++ b/packages/fe-tw/src/components/Trade/TradeForm.tsx
@@ -15,12 +15,12 @@ export default function TradeForm() {
     if (buildings?.length > 0) {
       setSelectedBuildingId(buildings[0].address);
     }
-  }, [buildings?.length]);
+  }, [buildings]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const amt = Number.parseFloat(amount);
-    if (isNaN(amt) || amt <= 0) {
+    if (Number.isNaN(amt) || amt <= 0) {
       toast.error("Invalid amount. Please enter a positive number.");
       return;
     }

--- a/packages/fe-tw/src/components/Trade/TradeFormOneSidedExchange.tsx
+++ b/packages/fe-tw/src/components/Trade/TradeFormOneSidedExchange.tsx
@@ -66,14 +66,14 @@ export default function TradeFormOneSidedExchange({ buildingTokens }: Props) {
 
     if (exchangeTokenBalance >= tokenBAmount) {
       return true;
-    } else {
-      toast.error(
-        `Not enough token balance to make a swap, it has only ${ethers.formatUnits(exchangeTokenBalance, 18)}`,
-      );
-      setMaxSwapTokenAmount(ethers.formatUnits(exchangeTokenBalance, 18));
-
-      return false;
     }
+
+    toast.error(
+      `Not enough token balance to make a swap, it has only ${ethers.formatUnits(exchangeTokenBalance, 18)}`,
+    );
+    setMaxSwapTokenAmount(ethers.formatUnits(exchangeTokenBalance, 18));
+
+    return false;
   };
 
   const handleSwapSubmit = async (e: React.FormEvent) => {
@@ -116,7 +116,7 @@ export default function TradeFormOneSidedExchange({ buildingTokens }: Props) {
 
   useEffect(() => {
     setMaxSwapTokenAmount(undefined);
-  }, [tradeFormData]);
+  }, []);
 
   return (
     <div className="flex-1 flex-col gap-4 w-6/12">

--- a/packages/fe-tw/src/components/Trade/TradePortfolio.tsx
+++ b/packages/fe-tw/src/components/Trade/TradePortfolio.tsx
@@ -67,7 +67,7 @@ export default function TradePortfolio({
               style={{ overflowY: "scroll", maxHeight: "50em" }}
             >
               {tradeHistory.map((tradeItem, id) => (
-                <TradePortfolioItem key={id} {...tradeItem} />
+                <TradePortfolioItem key={tradeItem.id} {...tradeItem} />
               ))}
             </div>
           </>

--- a/packages/fe-tw/src/components/Typography/TimeLabel.tsx
+++ b/packages/fe-tw/src/components/Typography/TimeLabel.tsx
@@ -19,12 +19,12 @@ export const TimeLabel = ({ date, formatType, prefix }: Props) => {
     <span className="text-stone-500 text-xs mx-2">
       {formatType === "dateAsTimeRange" ? (
         <>
-          {prefix ? prefix + "\n" : ""}
+          {prefix ? `${prefix}\n` : ""}
           {formatDistance(new Date(date), new Date(), { addSuffix: true })}
         </>
       ) : (
         <>
-          {prefix ? prefix + "\n" : ""}{" "}
+          {prefix ? `${prefix}\n` : ""}{" "}
           {format(new Date(date), formats[formatType] ?? "dd/MM/yyyy")}
         </>
       )}

--- a/packages/fe-tw/src/components/Wallets/WalletConnectModal.tsx
+++ b/packages/fe-tw/src/components/Wallets/WalletConnectModal.tsx
@@ -31,6 +31,7 @@ export function WalletConnectModal() {
     <>
       {accountId ? (
         <button
+          type="button"
           className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition"
           onClick={() => {
             walletInterface?.disconnect();
@@ -42,6 +43,7 @@ export function WalletConnectModal() {
       ) : (
         <>
           <button
+            type="button"
             className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition"
             onClick={handleOpenModal}
           >
@@ -49,10 +51,12 @@ export function WalletConnectModal() {
           </button>
 
           {isModalOpen && (
+            // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
             <div
               className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
               onClick={handleCloseModal}
             >
+              {/* biome-ignore lint/a11y/useKeyWithClickEvents: <explanation> */}
               <div
                 className="bg-white p-6 rounded-lg"
                 onClick={(e) => e.stopPropagation()}
@@ -60,6 +64,7 @@ export function WalletConnectModal() {
                 <h2 className="text-lg font-bold">Connect Wallet</h2>
                 <div className="flex flex-col gap-4 mt-4">
                   <button
+                    type="button"
                     className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition w-60"
                     onClick={() => {
                       connectToMetamask();
@@ -69,6 +74,7 @@ export function WalletConnectModal() {
                     MetaMask
                   </button>
                   <button
+                    type="button"
                     className="bg-purple-700 text-white px-4 py-2 rounded-full hover:bg-purple-900 transition w-60"
                     onClick={() => {
                       openWalletConnectModal();
@@ -80,6 +86,7 @@ export function WalletConnectModal() {
                 </div>
                 <div className="flex justify-end mt-4">
                   <button
+                    type="button"
                     className="bg-gray-200 text-black px-4 py-2 rounded-full hover:bg-gray-300 transition"
                     onClick={handleCloseModal}
                   >

--- a/packages/fe-tw/src/hooks/useBuildingDetails.ts
+++ b/packages/fe-tw/src/hooks/useBuildingDetails.ts
@@ -52,15 +52,15 @@ export function useBuildingDetails(buildingAddress: `0x${string}`) {
         }))
         .filter((log) => log.buildingAddress === buildingAddress),
     );
-  }, [newTokenForBuildingLogs?.length, buildingAddress]);
+  }, [newTokenForBuildingLogs, buildingAddress]);
 
   const isBuildingAdmin = useMemo(() => {
-    if (!!buildingOwner) {
+    if (buildingOwner) {
       return buildingOwner === evmAddress;
     }
 
     return false;
-  }, [buildingOwner]);
+  }, [buildingOwner, evmAddress]);
 
   return { isBuildingAdmin, deployedBuildingTokens };
 }

--- a/packages/fe-tw/src/hooks/useBuildings.ts
+++ b/packages/fe-tw/src/hooks/useBuildings.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { buildingFinancialMock } from "@/consts/buildings";
 import { readBuildingsList } from "@/services/buildingService";
@@ -117,7 +117,7 @@ export function useBuildings() {
   const [buildingsList, setBuildingsList] = useState<`0x${string}`[][]>([]);
   const [buildings, setBuildings] = useState<BuildingData[]>([]);
 
-  const fetchBuildingNFTs = async () => {
+  const fetchBuildingNFTs = useCallback(async () => {
     const { buildingNFTsData, buildingAddressesProxiesData } =
       await fetchBuildingNFTsMetadata(
         buildingsList.map((item) => item[0]),
@@ -133,7 +133,7 @@ export function useBuildings() {
         })),
       ),
     );
-  };
+  }, [buildings, buildingsList]);
 
   useEffect(() => {
     readBuildingsList().then((data) => {
@@ -145,7 +145,7 @@ export function useBuildings() {
     if (buildingsList?.length) {
       fetchBuildingNFTs();
     }
-  }, [buildingsList?.length]);
+  }, [buildingsList, fetchBuildingNFTs]);
 
   return { buildings };
 }

--- a/packages/fe-tw/src/hooks/useSliceData.ts
+++ b/packages/fe-tw/src/hooks/useSliceData.ts
@@ -60,6 +60,7 @@ export const useSliceData = (
       setSliceBuildings(
         sliceAllocations.map(
           (allocation) =>
+            // biome-ignore lint/style/noNonNullAssertion: <explanation>
             buildingDeployedTokens.find(
               (tok) => tok.tokenAddress === allocation.buildingToken,
             )!,

--- a/packages/fe-tw/src/hooks/useSlicesData.ts
+++ b/packages/fe-tw/src/hooks/useSlicesData.ts
@@ -6,7 +6,7 @@ import { watchContractEvent } from "@/services/contracts/watchContractEvent";
 import { fetchJsonFromIpfs } from "@/services/ipfsService";
 import type { SliceData } from "@/types/erc3643/types";
 import { prepareStorageIPFSfileURL } from "@/utils/helpers";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /**
  * Reads slice details from SC.
@@ -34,9 +34,9 @@ export function useSlicesData() {
         setSliceLogs(data);
       },
     });
-  }, [setSliceLogs]);
+  }, []);
 
-  const requestSlicesDetails = async () => {
+  const requestSlicesDetails = useCallback(async () => {
     const slicesMetadataUris = await Promise.all(
       sliceLogs.map((log) => readSliceMetdataUri(log.args[0])),
     );
@@ -59,13 +59,13 @@ export function useSlicesData() {
         estimatedPrice: 0,
       })),
     );
-  };
+  }, [sliceLogs]);
 
   useEffect(() => {
     if (sliceLogs?.length) {
       requestSlicesDetails();
     }
-  }, [sliceLogs?.length]);
+  }, [sliceLogs, requestSlicesDetails]);
 
   return {
     sliceAddresses,

--- a/packages/fe-tw/src/hooks/useSwapsHistory.ts
+++ b/packages/fe-tw/src/hooks/useSwapsHistory.ts
@@ -36,7 +36,7 @@ export const useSwapsHistory = () => {
         ...filterSwapHistoryItems(logs, evmAddress),
       ]);
     }
-  }, [logs.length]);
+  }, [logs, evmAddress]);
 
   useEffect(() => {
     const unlisten = watchContractEvent({

--- a/packages/fe-tw/src/hooks/vault/useATokenVaultData.ts
+++ b/packages/fe-tw/src/hooks/vault/useATokenVaultData.ts
@@ -44,7 +44,7 @@ export const useATokenVaultData = () => {
         setVaultLogs(data);
       },
     });
-  }, [setVaultLogs, setAutoCompounderLogs]);
+  }, []);
 
   useEffect(() => {
     if (vaultLogs?.length) {
@@ -56,7 +56,7 @@ export const useATokenVaultData = () => {
         })),
       );
     }
-  }, [vaultLogs?.length]);
+  }, [vaultLogs]);
 
   useEffect(() => {
     if (autoCompounderLogs?.length) {
@@ -68,7 +68,7 @@ export const useATokenVaultData = () => {
         })),
       );
     }
-  }, [autoCompounderLogs?.length]);
+  }, [autoCompounderLogs]);
 
   return {
     vaults,

--- a/packages/fe-tw/src/resources/icons/ArrowLeftIcon.tsx
+++ b/packages/fe-tw/src/resources/icons/ArrowLeftIcon.tsx
@@ -1,4 +1,5 @@
 export const ArrowLeftIcon = ({ size = "20" }) => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: <explanation>
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"

--- a/packages/fe-tw/src/resources/icons/ClockIcon.tsx
+++ b/packages/fe-tw/src/resources/icons/ClockIcon.tsx
@@ -1,5 +1,6 @@
 export const ClockIcon = ({ size = "20" }) => {
   return (
+    // biome-ignore lint/a11y/noSvgWithoutTitle: <explanation>
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={size}

--- a/packages/fe-tw/src/utils/sorting.ts
+++ b/packages/fe-tw/src/utils/sorting.ts
@@ -12,7 +12,6 @@ export const sortProposals = (
       return [...proposals].sort(
         (a, b) => moment(a.expiry).valueOf() - moment(b.expiry).valueOf(),
       );
-    case "votes":
     default:
       return [...proposals].sort(
         (a, b) => b.votesYes + b.votesNo - (a.votesYes + a.votesNo),

--- a/packages/fe-tw/src/utils/tagFilters.ts
+++ b/packages/fe-tw/src/utils/tagFilters.ts
@@ -8,8 +8,11 @@ export function getSliceTags(sliceName: string): string[] {
 
 export function getBuildingTags(building: any): string[] {
   const tags = new Set<string>();
+  // biome-ignore lint/complexity/noForEach: <explanation>
   tokenize(building.info.demographics.location).forEach((t) => tags.add(t));
+  // biome-ignore lint/complexity/noForEach: <explanation>
   tokenize(building.info.demographics.locationType).forEach((t) => tags.add(t));
+  // biome-ignore lint/complexity/noForEach: <explanation>
   tokenize(building.info.demographics.type).forEach((t) => tags.add(t));
   return Array.from(tags);
 }


### PR DESCRIPTION
**Description**:

This is a followup for the PR https://github.com/hashgraph/hedera-accelerator-rwa-re-ui/pull/61 with the linting errors fixes for `fe-tw` sub repo only.

```
Checked 238 files in 154ms. No fixes applied.
Found 57 warnings.

Process finished with exit code 0
```

There are still couple of things to note:
- some places had to be plugged with `biome-ignore` and would need a proper revisit
- there are some hooks with changed dependencies, please double check those
- there are a bunch of `any` types around the project, but they are warnings for now and should be addressed as a separate effort

I did not add any precommit hooks (like husky + lint-staged combo), nor switched out the bun/biome combo to smth like prettier/eslint not to increase the scope of the task even more.

Keep in mind current repo is setup as a monorepo, so there might be some additional tweaks needed for pipelines to separate what and when to lint.

- `npm run check-write` should be used as precommit call locally (and on save in your respective IDE)
- `npm run check` would be the command to run in CI/CD to see if we pass the check

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
